### PR TITLE
Fix non-matching closing tags

### DIFF
--- a/pub/index.html
+++ b/pub/index.html
@@ -14,8 +14,8 @@
     <body>
     <span  class="stdbody" style="font-size:48px">
         Schwobn in <br>
-        <span class="color-highlight"><div id="demo"></span>
-        </div>
+        <span class="color-highlight"><div id="demo"> </div>
+        </span>
     </span>
 
     <script>


### PR DESCRIPTION
`div` elements should be closed by a div tag and `span` elements should be closed by a span tag